### PR TITLE
Removed chargeAmount overload that has been removed from iZettle SDK.

### DIFF
--- a/Naxam.iZettle.iOS/ApiDefinition.cs
+++ b/Naxam.iZettle.iOS/ApiDefinition.cs
@@ -262,16 +262,6 @@ namespace iZettle
         // -(void)abortOperation;
         [Export("abortOperation")]
         void AbortOperation();
-
-        // - (void)chargeAmount:(NSDecimalNumber *)amount
-        //             currency:(nullable NSString *)currency
-        //            reference:(nullable NSString *)reference
-        // presentFromViewController:(UIViewController *)viewController
-        //           completion:(iZettleSDKOperationCompletion)completion
-        // __attribute__((deprecated("Use chargeAmount:currency:enableTipping:reference:presentFromViewController:completion: instead")));
-        // [Deprecated(PlatformName.iOS, PlatformArchitecture.All, "Use chargeAmount:currency:enableTipping:reference:presentFromViewController:completion: instead"),
-        [Export("chargeAmount:currency:reference:presentFromViewController:completion:")]
-        void ChargeAmount(NSDecimalNumber amount, [NullAllowed] string currency, [NullAllowed] string reference, UIViewController presentFromViewController, iZettleSDKOperationCompletion completion);
     }
 
     // @interface iZettleSDKPaymentInfo : NSObject


### PR DESCRIPTION
I removed chargeAmount overload that has a currency parameter since it has been removed from iZettle SDK.
Calling this overload will cause your app to crash (trust me, I know).

Currency seems (I am pretty new to Zettle so I not 100% sure about this though) to be set on Zettle user and cannot be changed by apps using the SDK.