### PR TITLE
Fixed  binding mistake

### DIFF
--- a/Naxam.iZettle.iOS/ApiDefinition.cs
+++ b/Naxam.iZettle.iOS/ApiDefinition.cs
@@ -227,7 +227,7 @@ namespace iZettle
         //                        completion:(IZSDKPayPalQRCCompletion)completion
         // NS_SWIFT_NAME(chargePayPalQRC(amount:reference:appearance:presentFrom:completion:))
         // API_AVAILABLE(ios(13));
-        [Export("chargePayPalQRCWithAmount:reference:appearance:presentedFromViewController:completion:")]
+        [Export("chargePayPalQRCWithAmount:reference:appearance:presentFromViewController:completion:")]
         void ChargePayPalQRCWithAmount(NSDecimalNumber amount, string reference, IZSDKPayPalQRCAppearance appearance, UIViewController presentedFromViewController, IZSDKPayPalQRCCompletion completion);
 
         // - (void)retrievePayPalQRCPaymentInfoForReference:(NSString *)reference


### PR DESCRIPTION
AS you can see from the commented out headers, the value was wrong.  https://github.com/iZettle/sdk-ios/blob/7ca129a845116a041eeff1357d0bdb77490ce50e/iZettleSDK/iZettleSDK.xcframework/ios-arm64_x86_64-simulator/iZettleSDK.framework/Headers/iZettleSDK.h#L295